### PR TITLE
Security Update: Externalized Glue Role ARN & Updated Bucket for Script Upload

### DIFF
--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -31,14 +31,20 @@ jobs:
       - name: Terraform Validate
         
         run: terraform validate
+        
 
       - name: Terraform Apply
         
         run: terraform apply -auto-approve
 
+        env:
+            TF_VAR_glue_role_arn: ${{ secrets.GLUE_ROLE_ARN }}
+
+        
+
       - name: Upload ETL Script to S3
         run: |
-          aws s3 cp lambdainvokingetl.py s3://bucketforgitfile123/data1/lambdainvokingetl.py
+          aws s3 cp lambdainvokingetl.py s3://automationteraform2310201/scripts/lambdainvokingetl.py
           echo "ETL script uploaded to S3."
 
       - name: Start Glue ETL Job

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -3,7 +3,7 @@ name: Terraform + ETL Automation
 on:
   push:
     branches:
-      - blade
+      - main
 
 jobs:
   infra-etl:

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -1,5 +1,5 @@
 name: Terraform + ETL Automation
-
+#123
 on:
   push:
     branches:

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.6  # You can change this version if needed
+          terraform_version: 1.6.6  # Change if needed
 
       - name: Terraform Init
         run: terraform init
@@ -33,9 +33,11 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
 
       - name: Terraform Apply
         run: terraform apply -auto-approve
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -1,0 +1,41 @@
+name: Terraform S3 Deploy
+
+on:
+  push:
+    branches:
+      - main  # triggers when you push to main branch
+
+jobs:
+  terraform:
+    name: Terraform Apply Job
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6  # You can change this version if needed
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Format Check
+        run: terraform fmt -check
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        run: terraform plan
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -1,5 +1,5 @@
 name: Terraform + ETL Automation
-#123
+#123456
 on:
   push:
     branches:

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload ETL Script to S3
         run: |
-          aws s3 cp lambdainvokingetl.py s3://automationthroughteraform2012310/scripts/lambdainvokingetl.py
+          aws s3 cp lambdainvokingetl.py s3://bucketforgitfile123/data1/lambdainvokingetl.py
           echo "ETL script uploaded to S3."
 
       - name: Start Glue ETL Job

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -25,15 +25,15 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        working-directory: infra
+        
         run: terraform init
 
       - name: Terraform Validate
-        working-directory: infra
+        
         run: terraform validate
 
       - name: Terraform Apply
-        working-directory: infra
+        
         run: terraform apply -auto-approve
 
       - name: Upload ETL Script to S3

--- a/.github/workflows/createrawbucket.yml
+++ b/.github/workflows/createrawbucket.yml
@@ -1,43 +1,68 @@
-name: Terraform S3 Deploy
+name: Terraform + ETL Automation
 
 on:
   push:
     branches:
-      - main  # triggers when you push to main branch
+      - blade
 
 jobs:
-  terraform:
-    name: Terraform Apply Job
+  infra-etl:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          terraform_version: 1.6.6  # Change if needed
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
+        working-directory: infra
         run: terraform init
 
-      - name: Terraform Format Check
-        run: terraform fmt -check
-
       - name: Terraform Validate
+        working-directory: infra
         run: terraform validate
 
-      - name: Terraform Plan
-        run: terraform plan
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-
       - name: Terraform Apply
+        working-directory: infra
         run: terraform apply -auto-approve
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+
+      - name: Upload ETL Script to S3
+        run: |
+          aws s3 cp lambdainvokingetl.py s3://automationthroughteraform2012310/scripts/lambdainvokingetl.py
+          echo "ETL script uploaded to S3."
+
+      - name: Start Glue ETL Job
+        id: start_etl
+        run: |
+          JOB_RUN_ID=$(aws glue start-job-run --job-name glue-etl-job201 --query 'JobRunId' --output text)
+          echo "ETL JobRunId: $JOB_RUN_ID"
+          echo "job_run_id=$JOB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for ETL Job Completion
+        run: |
+          JOB_RUN_ID=${{ steps.start_etl.outputs.job_run_id }}
+          while true; do
+            STATUS=$(aws glue get-job-run --job-name glue-etl-job201 --run-id "$JOB_RUN_ID" --query 'JobRun.JobRunState' --output text)
+            echo "Current ETL job status: $STATUS"
+            if [ "$STATUS" == "SUCCEEDED" ]; then
+              echo "ETL Job completed successfully."
+              break
+            elif [ "$STATUS" == "FAILED" ] || [ "$STATUS" == "STOPPED" ]; then
+              echo "ETL Job failed or stopped."
+              exit 1
+            fi
+            sleep 30
+          done
+
+      - name: Start Glue Crawler
+        run: aws glue start-crawler --name my-etl-crawler201

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+crash.log
+terraform.tfvars

--- a/lambdainvokingetl.py
+++ b/lambdainvokingetl.py
@@ -1,0 +1,29 @@
+
+from awsglue.context import GlueContext
+from pyspark.context import SparkContext
+import sys
+from awsglue.utils import getResolvedOptions
+from pyspark.sql import SparkSession
+
+# Get arguments passed from Lambda or Glue
+#args = getResolvedOptions(sys.argv, ['S3_Source_file', 'S3_Destination_file'])
+
+source_path = "s3://trans123321/abcd/"
+destination_path = "s3://newtransform123456/data/"
+# Create Spark and Glue Context
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+
+# Read CSV from S3
+df = spark.read.csv(source_path, inferSchema=True, header=True)
+
+# Drop unwanted columns
+columns_to_drop = ["community_area", "ward"]
+df = df.drop(*columns_to_drop)
+
+# Coalesce to a single output file
+df_single = df.coalesce(1)
+
+# Write back to S3 in CSV format
+df_single.write.mode("overwrite").option("header", "true").csv(destination_path)

--- a/lambdainvokingetl.py
+++ b/lambdainvokingetl.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 #args = getResolvedOptions(sys.argv, ['S3_Source_file', 'S3_Destination_file'])
 
 source_path = "s3://trans123321/abcd/"
-destination_path = "s3://automationthroughteraform2012310/cleaned_data/"
+destination_path = "s3://automationteraform2310201/"
 # Create Spark and Glue Context
 sc = SparkContext()
 glueContext = GlueContext(sc)

--- a/lambdainvokingetl.py
+++ b/lambdainvokingetl.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 #args = getResolvedOptions(sys.argv, ['S3_Source_file', 'S3_Destination_file'])
 
 source_path = "s3://trans123321/abcd/"
-destination_path = "s3://newtransform123456/data/"
+destination_path = "s3://automationthroughteraform2012310/cleaned_data/"
 # Create Spark and Glue Context
 sc = SparkContext()
 glueContext = GlueContext(sc)

--- a/lambdainvokingetl.py
+++ b/lambdainvokingetl.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 #args = getResolvedOptions(sys.argv, ['S3_Source_file', 'S3_Destination_file'])
 
 source_path = "s3://trans123321/abcd/"
-destination_path = "s3://automationteraform2310201/"
+destination_path = "s3://automationteraform2310201/cleaned_data/"
 # Create Spark and Glue Context
 sc = SparkContext()
 glueContext = GlueContext(sc)

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_glue_catalog_database" "etl_db" {
 }
 
 locals {
-  glue_role_arn = "arn:aws:iam::951764799690:role/LabRole"
+  glue_role_arn = var.glue_role_ar
 }
 
 resource "aws_glue_job" "etl_job" {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "raw_bucket" {
+  bucket = var.bucket_name
+  acl    = "private"
+
+  tags = {
+    Name        = "Raw Data Bucket"
+    Environment = "Dev"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,38 @@
-resource "aws_s3_bucket" "raw_bucket" {
-  bucket = var.bucket_name
-  acl    = "private"
+resource "aws_s3_bucket" "etl_bucket" {
+  bucket = var.bucket_name_prefix
+}
 
-  tags = {
-    Name        = "Raw Data Bucket"
-    Environment = "Dev"
+resource "aws_glue_catalog_database" "etl_db" {
+  name = "crime_db"
+}
+
+locals {
+  glue_role_arn = "arn:aws:iam::951764799690:role/LabRole"
+}
+
+resource "aws_glue_job" "etl_job" {
+  name     = var.glue_job_name
+  role_arn = local.glue_role_arn
+
+  command {
+    name            = "glueetl"
+    script_location = var.script_s3_path
+    python_version  = "3"
   }
+
+  glue_version      = "4.0"
+  number_of_workers = 2
+  worker_type       = "G.1X"
+}
+
+resource "aws_glue_crawler" "etl_crawler" {
+  name          = var.glue_crawler_name
+  role          = local.glue_role_arn
+  database_name = aws_glue_catalog_database.etl_db.name
+
+  s3_target {
+    path = "s3://${var.bucket_name_prefix}/cleaned_data/"
+  }
+
+  depends_on = [aws_glue_job.etl_job]
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "etl_bucket" {
 }
 
 resource "aws_glue_catalog_database" "etl_db" {
-  name = "crime_db"
+  name = "crime_db123"
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,8 @@ resource "aws_glue_crawler" "etl_crawler" {
   database_name = aws_glue_catalog_database.etl_db.name
 
   s3_target {
-    path = "s3://${var.bucket_name_prefix}/cleaned_data/"
-  }
+    path = "s3://${aws_s3_bucket.etl_bucket.bucket}/cleaned_data/"
+ }
 
   depends_on = [aws_glue_job.etl_job]
 }

--- a/output.tf
+++ b/output.tf
@@ -1,4 +1,7 @@
-output "bucket_name" {
-  description = "The name of the S3 bucket"
-  value       = aws_s3_bucket.raw_bucket.id
+output "glue_job_name" {
+  value = aws_glue_job.etl_job.name
+}
+
+output "glue_crawler_name" {
+  value = aws_glue_crawler.etl_crawler.name
 }

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "The name of the S3 bucket"
+  value       = aws_s3_bucket.raw_bucket.id
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-  region = var.aws_region
+  region = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,13 @@ variable "region" {
   default = "us-east-1"
 }
 
+
+variable "glue_role_arn" {
+  description = "IAM role ARN to use for Glue Job"
+  type        = string
+}
+
+
 #declare a bucket name
 variable "bucket_name_prefix" {
   default = "automationteraform2310201"
@@ -21,5 +28,5 @@ variable "glue_crawler_name" {
 
 #declare a script path
 variable "script_s3_path" {
-  default = "s3://bucketforgitfile123/data1/lambdainvokingetl.py"
+  default = "s3://automationteraform2310201/scripts/lambdainvokingetl.py"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,5 +21,5 @@ variable "glue_crawler_name" {
 
 #declare a script path
 variable "script_s3_path" {
-  default = "s3:/bucketforgitfile123/data1/lambdainvokingetl.py"
+  default = "s3://bucketforgitfile123/data1/lambdainvokingetl.py"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,5 +7,5 @@ variable "aws_region" {
 variable "bucket_name" {
   description = "S3 bucket name"
   type        = string
-  default     = "my-simple-terraform-bucket-123456"
+  default     = "my-terraform-bucket-yogesh-kerkar-202508051133"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,5 +21,5 @@ variable "glue_crawler_name" {
 
 #declare a script path
 variable "script_s3_path" {
-  default = "s3://automationthroughteraform2012310/scripts/lambdainvokingetl.py"
+  default = "s3:/bucketforgitfile123/data1/lambdainvokingetl.py"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name"
+  type        = string
+  default     = "my-simple-terraform-bucket-123456"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,25 @@
-variable "aws_region" {
-  description = "AWS region"
-  type        = string
-  default     = "us-east-1"
+#declare a region
+variable "region" {
+  default = "us-east-1"
 }
 
-variable "bucket_name" {
-  description = "S3 bucket name"
-  type        = string
-  default     = "my-terraform-bucket-yogesh-kerkar-202508051133"
+#declare a bucket name
+variable "bucket_name_prefix" {
+  default = "automationteraform2310201"
+}
+
+
+#declare a glue job name
+variable "glue_job_name" {
+  default = "glue-etl-job201"
+}
+
+#declare a crawler name
+variable "glue_crawler_name" {
+  default = "my-etl-crawler201"
+}
+
+#declare a script path
+variable "script_s3_path" {
+  default = "s3://automationthroughteraform2012310/scripts/lambdainvokingetl.py"
 }


### PR DESCRIPTION
Secured Glue Role ARN by externalizing it into a GitHub Actions secret variable (GLUE_ROLE_ARN) instead of hardcoding it in Terraform.
Updated the S3 bucket name where the Glue ETL script will be uploaded automatically.